### PR TITLE
Refactor encryption to standards

### DIFF
--- a/config/global.config.php
+++ b/config/global.config.php
@@ -3,8 +3,8 @@
 namespace ZfDoctrineEncryptModule;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use ZfDoctrineEncryptModule\Adapter\HaliteAdapter;
-use ZfDoctrineEncryptModule\Factory\HaliteAdapterFactory;
+use ZfDoctrineEncryptModule\Adapter\HaliteEncryptionAdapter;
+use ZfDoctrineEncryptModule\Factory\HaliteEncryptionAdapterFactory;
 use ZfDoctrineEncryptModule\Factory\ZfDoctrineEncryptedServiceFactory;
 
 return [
@@ -28,11 +28,11 @@ return [
     ],
     'service_manager' => [
         'aliases' => [
-            'encryption_adapter' => HaliteAdapter::class,
+            'encryption_adapter' => HaliteEncryptionAdapter::class,
         ],
         'factories' => [
             // Using aliases so someone else can use own adapter/factory
-            HaliteAdapter::class => HaliteAdapterFactory::class
+            HaliteEncryptionAdapter::class => HaliteEncryptionAdapterFactory::class
         ],
     ],
 ];

--- a/config/local.config.php.dist
+++ b/config/local.config.php.dist
@@ -7,7 +7,6 @@ return [
         'encryption' => [
             'orm_default' => [
                 'key' => '',    // Must be 32 characters - Halite requirement
-                'salt' => '',   // Must be 32 characters - Halite requirement
             ],
         ],
     ],

--- a/src/Adapter/HaliteEncryptionAdapter.php
+++ b/src/Adapter/HaliteEncryptionAdapter.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace ZfDoctrineEncryptModule\Adapter;
+
+use DoctrineEncrypt\Encryptors\EncryptorInterface;
+use ParagonIE\ConstantTime\Binary;
+use ParagonIE\Halite\Alerts\InvalidKey;
+use ParagonIE\Halite\HiddenString;
+use ParagonIE\Halite\Symmetric\Crypto;
+use ParagonIE\Halite\Symmetric\EncryptionKey;
+
+class HaliteEncryptionAdapter implements EncryptorInterface
+{
+    /**
+     * @var EncryptionKey
+     */
+    private $key;
+
+    /**
+     * HaliteAdapter constructor.
+     * @param $key
+     * @throws InvalidKey
+     * @throws \TypeError
+     */
+    public function __construct($key)
+    {
+        if (Binary::safeStrlen($key) !== \Sodium\CRYPTO_STREAM_KEYBYTES) {
+
+            throw new InvalidKey(
+                'Encryption key used for ' . __CLASS__ . '::' . __FUNCTION__ . ' must be exactly ' . \Sodium\CRYPTO_STREAM_KEYBYTES . ' characters long'
+            );
+        }
+
+        $this->setKey((new EncryptionKey((new HiddenString($key)))));
+    }
+
+    /**
+     * @param string $data
+     * @return string
+     * @throws \ParagonIE\Halite\Alerts\CannotPerformOperation
+     * @throws \ParagonIE\Halite\Alerts\InvalidDigestLength
+     * @throws \ParagonIE\Halite\Alerts\InvalidMessage
+     * @throws \ParagonIE\Halite\Alerts\InvalidType
+     */
+    public function encrypt($data)
+    {
+        return Crypto::encrypt(new HiddenString($data), $this->getKey());
+    }
+
+    /**
+     * @param string $data
+     * @return HiddenString|string
+     * @throws \ParagonIE\Halite\Alerts\CannotPerformOperation
+     * @throws \ParagonIE\Halite\Alerts\InvalidDigestLength
+     * @throws \ParagonIE\Halite\Alerts\InvalidMessage
+     * @throws \ParagonIE\Halite\Alerts\InvalidSignature
+     * @throws \ParagonIE\Halite\Alerts\InvalidType
+     */
+    public function decrypt($data)
+    {
+        return Crypto::decrypt($data, $this->getKey());
+    }
+
+    /**
+     * @return EncryptionKey
+     */
+    public function getKey(): EncryptionKey
+    {
+        return $this->key;
+    }
+
+    /**
+     * @param EncryptionKey $key
+     * @return HaliteEncryptionAdapter
+     */
+    public function setKey(EncryptionKey $key): HaliteEncryptionAdapter
+    {
+        $this->key = $key;
+        return $this;
+    }
+}

--- a/src/Annotation/Encrypted.php
+++ b/src/Annotation/Encrypted.php
@@ -5,10 +5,7 @@ namespace ZfDoctrineEncryptModule\Annotation;
 use Doctrine\Common\Annotations\Annotation\Target;
 
 /**
- * Class Encrypted
- * @package ZfDoctrineEncryptModule\Annotation
- *
- * The below register the class as to be used as Doctrine's Annotation and only on class properties.
+ * The below register the class as to be used as Doctrine's Annotation and only on properties.
  *
  * @Annotation
  * @Target("PROPERTY")
@@ -16,78 +13,9 @@ use Doctrine\Common\Annotations\Annotation\Target;
 class Encrypted
 {
     /**
-     * @var string linked property which implements \ZfDoctrineEncryptModule\Interfaces\SpicyInterface
-     */
-    public $spices;
-
-    /**
-     * @var string linked property which implements \ZfDoctrineEncryptModule\Interfaces\SaltInterface
-     */
-    public $salt;
-
-    /**
-     * @var string linked property which implements \ZfDoctrineEncryptModule\Interfaces\PepperInterface
-     */
-    public $pepper;
-
-    /**
      * @var string type that the encrypted/decrypted string should be
      */
     public $type = 'string';
-
-    /**
-     * @return string
-     */
-    public function getSpices(): ?string
-    {
-        return $this->spices;
-    }
-
-    /**
-     * @param string $spices
-     * @return Encrypted
-     */
-    public function setSpices(?string $spices): Encrypted
-    {
-        $this->spices = $spices;
-        return $this;
-    }
-
-    /**
-     * @return null|string
-     */
-    public function getSalt(): ?string
-    {
-        return $this->salt;
-    }
-
-    /**
-     * @param null|string $salt
-     * @return Encrypted
-     */
-    public function setSalt(?string $salt): Encrypted
-    {
-        $this->salt = $salt;
-        return $this;
-    }
-
-    /**
-     * @return null|string
-     */
-    public function getPepper(): ?string
-    {
-        return $this->pepper;
-    }
-
-    /**
-     * @param null|string $pepper
-     * @return Encrypted
-     */
-    public function setPepper(?string $pepper): Encrypted
-    {
-        $this->pepper = $pepper;
-        return $this;
-    }
 
     /**
      * @return null|string

--- a/src/Factory/HaliteEncryptionAdapterFactory.php
+++ b/src/Factory/HaliteEncryptionAdapterFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ZfDoctrineEncryptModule\Factory;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Factory\FactoryInterface;
+use ZfDoctrineEncryptModule\Adapter\HaliteEncryptionAdapter;
+use ZfDoctrineEncryptModule\Exception\OptionsNotFoundException;
+
+class HaliteEncryptionAdapterFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param array|null $options
+     * @return HaliteEncryptionAdapter
+     * @throws OptionsNotFoundException
+     * @throws \ParagonIE\Halite\Alerts\InvalidKey
+     * @throws \TypeError
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        if (!is_array($options) || empty($options)) {
+
+            throw new OptionsNotFoundException('Options required to be set in the config for HaliteAdapter are "key".');
+        }
+
+        if (!key_exists('key', $options) && !is_string($options['key'])) {
+
+            throw new OptionsNotFoundException('Option "key" is required.');
+        }
+
+        return new HaliteEncryptionAdapter($options['key']);
+    }
+}

--- a/src/Factory/ZfDoctrineEncryptedServiceFactory.php
+++ b/src/Factory/ZfDoctrineEncryptedServiceFactory.php
@@ -8,7 +8,7 @@ use DoctrineEncrypt\Encryptors\EncryptorInterface;
 use DoctrineModule\Service\AbstractFactory;
 use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
-use ZfDoctrineEncryptModule\Adapter\HaliteAdapter;
+use ZfDoctrineEncryptModule\Adapter\HaliteEncryptionAdapter;
 use ZfDoctrineEncryptModule\Options\ModuleOptions;
 use ZfDoctrineEncryptModule\Subscriber\DoctrineEncryptSubscriber;
 
@@ -27,13 +27,12 @@ class ZfDoctrineEncryptedServiceFactory extends AbstractFactory
 
         /** @var Reader|AnnotationReader $reader */
         $reader = $this->createReader($container, $options->getReader());
-        /** @var EncryptorInterface|HaliteAdapter $adapter */
+        /** @var EncryptorInterface|HaliteEncryptionAdapter $adapter */
         $adapter = $this->createAdapter(
             $container,
             $options->getAdapter(),
             [
                 'key' => $options->getKey(),
-                'salt' => $options->getSalt(),
             ]
         );
 


### PR DESCRIPTION
Asked for review of implementation on Information Security SE [here](https://security.stackexchange.com/questions/183386/would-this-be-secure-enough-zf3-doctrine-module-using-halite). After answer and some discussion in comments, conclusion was that implementation here was incorrect and actually lowered security somewhat. 

As such a big refactor, which happily also makes implementation somewhat simpler. 

In preparation for support for hashing, it also contains class renaming, so it must be a major version upgrade as it will cause a BC break.